### PR TITLE
Add error case test for FileUpload

### DIFF
--- a/app/facturas/__tests__/page.test.tsx
+++ b/app/facturas/__tests__/page.test.tsx
@@ -23,6 +23,7 @@ jest.mock('next/navigation', () => ({
   }),
   usePathname: () => '/facturas',
   useSearchParams: () => new URLSearchParams(),
+  redirect: jest.fn(),
 }))
 
 // Mock next-auth
@@ -67,28 +68,9 @@ jest.mock('@/lib/hooks/useInvoices', () => ({
 }))
 
 describe('FacturasPage', () => {
-  it('renders upload section', () => {
+  it('redirects to received invoices', () => {
+    const { redirect } = require('next/navigation')
     render(<FacturasPage />)
-    expect(screen.getByText(/arrastra y suelta tu factura aquí/i)).toBeInTheDocument()
+    expect(redirect).toHaveBeenCalledWith('/facturas/recibidas')
   })
-
-  it('renders table headers', () => {
-    render(<FacturasPage />)
-    expect(screen.getByRole('button', { name: /número/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /fecha/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /proveedor/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /total/i })).toBeInTheDocument()
-  })
-
-  it('shows loading state when fetching invoices', () => {
-    jest.spyOn(require('@/lib/hooks/useInvoices'), 'useInvoices').mockImplementation(() => ({
-      invoices: [],
-      isLoading: true,
-      error: null,
-      refetch: jest.fn(),
-    }))
-
-    render(<FacturasPage />)
-    expect(screen.getByText(/cargando/i)).toBeInTheDocument()
-  })
-}) 
+})

--- a/components/facturas/__tests__/FileUpload.test.tsx
+++ b/components/facturas/__tests__/FileUpload.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { FileUpload } from '../FileUpload'
 
+const mockToast = jest.fn((opts: { description: string }) => {
+  const div = document.createElement('div')
+  div.textContent = opts.description
+  document.body.appendChild(div)
+})
+
+jest.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: mockToast })
+}))
+
 describe('FileUpload', () => {
   const mockOnUpload = jest.fn()
 
@@ -48,4 +58,18 @@ describe('FileUpload', () => {
     
     expect(screen.queryByText(/subiendo archivo/i)).not.toBeInTheDocument()
   })
-}) 
+
+  it('shows error toast on upload failure', async () => {
+    mockOnUpload.mockRejectedValue(new Error('fail'))
+    render(<FileUpload onUpload={mockOnUpload} />)
+
+    const file = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+    const input = screen.getByTestId('file-input')
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } })
+    })
+
+    expect(await screen.findByText('Ha ocurrido un error al subir el archivo.')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- expand FileUpload tests with upload failure scenario
- mock toast hook for DOM text verification
- clean up page tests to expect redirect instead of UI

## Testing
- `npm test` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_686be1a84c088328a461005748bcdd78