### PR TITLE
fix: return correct data from uploadInvoice

### DIFF
--- a/lib/services/googleDrive.ts
+++ b/lib/services/googleDrive.ts
@@ -144,5 +144,5 @@ export async function uploadInvoice(file: File) {
     throw new Error(data.error || 'Error al subir el archivo');
   }
 
-  return data.file;
-} 
+  return data;
+}


### PR DESCRIPTION
## Summary
- ensure `uploadInvoice` returns the full response from the backend instead of the non-existent `file` property

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bdff0238483289bf73175eac6c2aa