### PR TITLE
Fix failing FacturasPage tests

### DIFF
--- a/app/facturas/__tests__/page.test.tsx
+++ b/app/facturas/__tests__/page.test.tsx
@@ -1,94 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import FacturasPage from '../page'
+import { redirect } from 'next/navigation'
 
-const mockInvoices = [
-  {
-    id: '1',
-    invoiceNumber: 'F001',
-    invoiceDate: '2024-03-20',
-    invoiceDescription: 'Factura de servicios',
-    supplierName: 'Proveedor Test',
-    totalPriceIncVat: 1000,
-    paid: true,
-    driveUrl: 'https://drive.google.com/test'
-  }
-]
-
-// Mock next/navigation
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: jest.fn(),
-    replace: jest.fn(),
-    prefetch: jest.fn(),
-  }),
-  usePathname: () => '/facturas',
-  useSearchParams: () => new URLSearchParams(),
-}))
-
-// Mock next-auth
-jest.mock('next-auth/react', () => ({
-  useSession: () => ({
-    data: {
-      user: {
-        name: 'Test User',
-        email: 'test@example.com',
-      },
-    },
-    status: 'authenticated',
-  }),
-}))
-
-// Mock googleapis
-jest.mock('googleapis', () => ({
-  google: {
-    auth: {
-      GoogleAuth: jest.fn().mockImplementation(() => ({
-        getClient: jest.fn(),
-      })),
-    },
-    drive: jest.fn().mockImplementation(() => ({
-      files: {
-        create: jest.fn(),
-        get: jest.fn(),
-        list: jest.fn(),
-      },
-    })),
-  },
-}))
-
-// Mock useInvoices hook
-jest.mock('@/lib/hooks/useInvoices', () => ({
-  useInvoices: () => ({
-    invoices: mockInvoices,
-    isLoading: false,
-    error: null,
-    refetch: jest.fn(),
-  }),
+  redirect: jest.fn()
 }))
 
 describe('FacturasPage', () => {
-  it('renders upload section', () => {
+  it('redirects to received invoices', () => {
     render(<FacturasPage />)
-    expect(screen.getByText(/arrastra y suelta tu factura aquí/i)).toBeInTheDocument()
+    expect(redirect).toHaveBeenCalledWith('/facturas/recibidas')
   })
-
-  it('renders table headers', () => {
-    render(<FacturasPage />)
-    expect(screen.getByRole('button', { name: /número/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /fecha/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /proveedor/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /total/i })).toBeInTheDocument()
-  })
-
-  it('shows loading state when fetching invoices', () => {
-    jest.spyOn(require('@/lib/hooks/useInvoices'), 'useInvoices').mockImplementation(() => ({
-      invoices: [],
-      isLoading: true,
-      error: null,
-      refetch: jest.fn(),
-    }))
-
-    render(<FacturasPage />)
-    expect(screen.getByText(/cargando/i)).toBeInTheDocument()
-  })
-}) 
+})

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -17,6 +17,7 @@ jest.mock('next/navigation', () => ({
   useSearchParams() {
     return new URLSearchParams()
   },
+  redirect: jest.fn(),
 }))
 
 // Mock next-auth


### PR DESCRIPTION
## Summary
- ensure `next/navigation` mock includes `redirect`
- update FacturasPage unit test to expect a redirect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bdd919c30832886d718fe51e7da0b